### PR TITLE
Update Android SDK path defaults

### DIFF
--- a/src/komodo_codex_env/android_manager.py
+++ b/src/komodo_codex_env/android_manager.py
@@ -23,8 +23,8 @@ class AndroidManager:
         self.executor = executor
         self.dep_manager = dep_manager
         
-        # Android SDK paths - use /opt/android-sdk-linux for consistency with Docker
-        self.android_home = Path("/opt/android-sdk-linux")
+        # Android SDK paths - default to config value or system path
+        self.android_home = config.android_home if config.android_home else Path("/opt/android-sdk")
         self.android_tools_dir = self.android_home / "tools"
         self.android_platform_tools_dir = self.android_home / "platform-tools"
         self.android_cmdline_tools_dir = self.android_home / "cmdline-tools" / "latest"

--- a/src/komodo_codex_env/config.py
+++ b/src/komodo_codex_env/config.py
@@ -68,7 +68,8 @@ class EnvironmentConfig:
             self.initial_dir = Path.cwd()
 
         if self.android_home is None:
-            self.android_home = self.home_dir / "Android" / "Sdk"
+            # Default to system-wide installation path
+            self.android_home = Path("/opt/android-sdk")
 
     @property
     def script_gist_url(self) -> str:
@@ -109,6 +110,11 @@ class EnvironmentConfig:
         config.should_fetch_agents_docs = os.getenv("SHOULD_FETCH_AGENTS_DOCS", "true").lower() == "true"
         config.should_fetch_kdf_api_docs = os.getenv("SHOULD_FETCH_KDF_API_DOCS", "false").lower() == "true"
         config.install_android_sdk = os.getenv("INSTALL_ANDROID_SDK", "true").lower() == "true"
+
+        # Android SDK path override
+        android_home_env = os.getenv("ANDROID_HOME") or os.getenv("ANDROID_SDK_ROOT")
+        if android_home_env:
+            config.android_home = Path(android_home_env)
 
         # Handle platforms
         platforms_env = os.getenv("PLATFORMS")

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -100,7 +100,7 @@ python -m unittest tests.integration.test_komodo_wallet_build.EnvironmentSetupTe
 ### Android SDK Paths
 
 The tests support multiple Android SDK installation locations:
-- System-wide: `/opt/android-sdk-linux` (default from android_manager.py)
+- System-wide: `/opt/android-sdk` (default from android_manager.py)
 - User-specific: `/home/testuser/Android/Sdk` (fallback)
 
 ### Environment Variables

--- a/tests/integration/test_komodo_wallet_build.py
+++ b/tests/integration/test_komodo_wallet_build.py
@@ -19,7 +19,7 @@ INSTALL_SCRIPT = PROJECT_ROOT / "install.sh"
 KOMODO_WALLET_REPO = "https://github.com/KomodoPlatform/komodo-wallet.git"
 
 # Android SDK configuration (matching android_manager.py)
-ANDROID_HOME = "/opt/android-sdk-linux"
+ANDROID_HOME = "/opt/android-sdk"
 ANDROID_USER_HOME = "/home/testuser/Android/Sdk"  # Fallback for user-specific installation
 
 # Configure logging


### PR DESCRIPTION
## Summary
- default to `/opt/android-sdk` for Android SDK location
- read `ANDROID_HOME` or `ANDROID_SDK_ROOT` env var
- use config value in `AndroidManager`
- update integration tests

## Testing
- `uv run pytest -q`