### PR TITLE
Switch documentation to Rye package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Python-based replacement for the original bash script to set up Flutter develo
 ### Prerequisites
 
 - Python 3.11+ (Python 3.13 recommended)
-- `uv` package manager
+- [Rye](https://rye.astral.sh/) package manager
 - Git
 - FVM (Flutter Version Management) - installed automatically
 - Java 17+ (OpenJDK) - installed automatically for Android development
@@ -29,6 +29,12 @@ A Python-based replacement for the original bash script to set up Flutter develo
 ```bash
 # Quick install with all dependencies and FVM setup
 curl -fsSL https://raw.githubusercontent.com/KomodoPlatform/komodo-codex-env/main/install.sh | bash
+
+# Example with custom options
+curl -fsSL https://raw.githubusercontent.com/KomodoPlatform/komodo-codex-env/main/install.sh | bash -s -- \
+  --flutter-version 3.32.0 \
+  --platforms web,android \
+  --install-type ALL
 ```
 
 ### Manual Installation
@@ -39,10 +45,10 @@ git clone <repository-url>
 cd komodo-codex-env
 
 # Install dependencies
-uv sync --dev
+rye sync
 
 # Run the setup with FVM
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --verbose
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --verbose
 ```
 
 ## Project Structure
@@ -75,46 +81,46 @@ komodo-codex-env/
 
 ```bash
 # Full environment setup with FVM
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup
 
 # Setup with custom Flutter version
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --flutter-version 3.29.3
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --flutter-version 3.29.3
 
 # Setup with specific platforms (Android SDK auto-installed if android is included)
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --platforms web,android,linux
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --platforms web,android,linux
 
 # Skip Android SDK installation
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --no-android
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --no-android
 
 # Verbose output
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --verbose
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --verbose
 ```
 
 ### Individual Commands
 
 ```bash
 # Check system dependencies
-PYTHONPATH=src uv run python -m komodo_codex_env.cli check-deps
+PYTHONPATH=src rye run python -m komodo_codex_env.cli check-deps
 
 # Check Flutter status via FVM
-PYTHONPATH=src uv run python -m komodo_codex_env.cli flutter-status
+PYTHONPATH=src rye run python -m komodo_codex_env.cli flutter-status
 
 # Fetch documentation only
-PYTHONPATH=src uv run python -m komodo_codex_env.cli fetch-docs
+PYTHONPATH=src rye run python -m komodo_codex_env.cli fetch-docs
 
 # FVM Flutter management
-PYTHONPATH=src uv run python -m komodo_codex_env.cli fvm-list
-PYTHONPATH=src uv run python -m komodo_codex_env.cli fvm-install 3.29.3
-PYTHONPATH=src uv run python -m komodo_codex_env.cli fvm-use 3.29.3
-PYTHONPATH=src uv run python -m komodo_codex_env.cli fvm-releases
+PYTHONPATH=src rye run python -m komodo_codex_env.cli fvm-list
+PYTHONPATH=src rye run python -m komodo_codex_env.cli fvm-install 3.29.3
+PYTHONPATH=src rye run python -m komodo_codex_env.cli fvm-use 3.29.3
+PYTHONPATH=src rye run python -m komodo_codex_env.cli fvm-releases
 
 # Android SDK management
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-status
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-install
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-licenses
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-status
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-install
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-licenses
 
 # Update script from remote
-PYTHONPATH=src uv run python -m komodo_codex_env.cli update-script
+PYTHONPATH=src rye run python -m komodo_codex_env.cli update-script
 ```
 
 ## Configuration
@@ -180,19 +186,19 @@ export MAX_PARALLEL_JOBS=4
 
 ```bash
 # Install development dependencies
-uv sync --dev
+rye sync
 
 # Run tests
-uv run pytest
+rye run pytest
 
 # Format code
-uv run black src/
+rye run ruff format src/
 
 # Type checking
-uv run mypy src/
+rye run mypy src/
 
 # Run the tool locally
-PYTHONPATH=src uv run python -m komodo_codex_env.cli --help
+PYTHONPATH=src rye run python -m komodo_codex_env.cli --help
 ```
 
 ## Migration from Bash Script
@@ -250,13 +256,13 @@ Android SDK installation is handled through the main CLI tool:
 
 ```bash
 # Install Android SDK only
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-install
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-install
 
 # Check Android SDK status
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-status
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-status
 
 # Accept Android licenses
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-licenses
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-licenses
 ```
 
 ### Development Scripts
@@ -310,7 +316,7 @@ When using the main setup command with `android` in platforms, Flutter and Andro
 
 ```bash
 # This installs Flutter via FVM and Android SDK simultaneously
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --platforms web,android
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --platforms web,android
 ```
 
 </edits>

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -35,21 +35,16 @@ komodo-codex-env/
 │   ├── android/                        # Android-specific documentation
 │   │   ├── ANDROID_SDK_GUIDE.md        # User guide for Android SDK
 │   │   └── ANDROID_SDK_IMPLEMENTATION.md # Technical implementation details
-│   └── commit_conventions.md           # Git commit conventions
 ├── .venv/                              # Python virtual environment
 ├── .git/                               # Git repository data
 ├── .gitignore                          # Git ignore rules
 ├── .python-version                     # Python version specification
-├── .ropeproject/                       # Rope IDE configuration
-├── AGENTS.md                           # Agent documentation
-├── KDF_API_DOCUMENTATION.md           # KDF API documentation
 ├── PROJECT_STRUCTURE.md               # This file
 ├── README.md                           # Main project README
 ├── install.sh                          # Main installation script
 ├── pyproject.toml                      # Python project configuration
-├── requirements-dev.txt                # Development dependencies
-├── requirements.txt                    # Runtime dependencies
-└── uv.lock                            # UV package lock file
+├── requirements-dev.lock               # Locked development dependencies
+├── requirements.lock                   # Locked runtime dependencies
 ```
 
 ## Core Components (src/komodo_codex_env/)
@@ -116,27 +111,26 @@ komodo-codex-env/
 - **`bloc_conventions.md`** - Coding conventions for BLoC pattern
 - **`bloc_modeling.md`** - Data modeling guidelines
 - **`bloc_testing.md`** - Testing strategies for BLoC components
-- **`commit_conventions.md`** - Git commit message standards
 
 ## Usage Patterns
 
 ### Primary Workflows
 
-1. **Full Environment Setup**: `PYTHONPATH=src uv run python -m komodo_codex_env.cli setup`
+1. **Full Environment Setup**: `PYTHONPATH=src rye run python -m komodo_codex_env.cli setup`
 2. **Development Environment**: `./scripts/setup_dev_env.sh`
 3. **Development Testing**: `python scripts/run_tests.py unit`
 
 ### Configuration Files
 
 - **`pyproject.toml`** - Python project metadata and dependencies
-- **`uv.lock`** - Locked dependency versions for reproducible builds
+- **`requirements.lock`** - Locked runtime dependencies
 - **`.python-version`** - Python version specification for version managers
 
 ### Environment Management
 
 - **`.venv/`** - Isolated Python environment for development
-- **`requirements.txt`** - Runtime dependencies
-- **`requirements-dev.txt`** - Development and testing dependencies
+- **`requirements.lock`** - Locked runtime dependencies
+- **`requirements-dev.lock`** - Locked development dependencies
 
 ## Key Features by Location
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,8 +63,6 @@ The implementation documentation covers:
 
 - Main project README: [`../README.md`](../README.md)
 - Scripts documentation: [`../scripts/README.md`](../scripts/README.md)
-- Agent documentation: [`../AGENTS.md`](../AGENTS.md)
-- KDF API documentation: [`../KDF_API_DOCUMENTATION.md`](../KDF_API_DOCUMENTATION.md)
 
 ## Contributing
 

--- a/docs/flutter/android/ANDROID_SDK_GUIDE.md
+++ b/docs/flutter/android/ANDROID_SDK_GUIDE.md
@@ -18,24 +18,24 @@ The Android SDK installation is integrated as a parallel setup step alongside th
 
 ```bash
 # Install Flutter + Android SDK in parallel
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --platforms web,android
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --platforms web,android
 
 # Or with verbose output
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --platforms web,android --verbose
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --platforms web,android --verbose
 ```
 
 ### Option 2: Android SDK Only
 
 ```bash
 # Using the CLI
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-install
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-install
 ```
 
 ### Option 3: Skip Android SDK
 
 ```bash
 # Skip Android SDK installation
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --no-android
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --no-android
 ```
 
 ## Installation Components
@@ -102,33 +102,33 @@ After installation, your Android SDK will be organized as:
 
 ```bash
 # Check Android SDK installation status
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-status
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-status
 
 # Check overall Flutter environment
-PYTHONPATH=src uv run python -m komodo_codex_env.cli flutter-status
+PYTHONPATH=src rye run python -m komodo_codex_env.cli flutter-status
 ```
 
 ### Installation Commands
 
 ```bash
 # Install Android SDK
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-install
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-install
 
 # Accept Android licenses
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-licenses
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-licenses
 ```
 
 ### CLI Command Options
 
 ```bash
 # Using the main CLI tool
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-install
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-install
 
 # Check Android SDK status
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-status
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-status
 
 # Accept Android licenses
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-licenses
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-licenses
 ```
 
 ## Environment Variables
@@ -215,7 +215,7 @@ When using the main setup command with `android` in platforms, the tool runs Flu
 
 ```bash
 # This runs Flutter FVM setup and Android SDK installation simultaneously
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --platforms web,android
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --platforms web,android
 ```
 
 **Benefits:**
@@ -281,7 +281,7 @@ Manual Java installation required. Download from:
 
 ```bash
 # Run with verbose output for debugging
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --platforms android --verbose
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --platforms android --verbose
 
 # Check detailed Flutter doctor output
 flutter doctor -v
@@ -309,7 +309,7 @@ ls ~/Android/Sdk/platforms/
 # GitHub Actions example
 - name: Setup Flutter with Android SDK
   run: |
-    PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --platforms web,android --no-docs
+    PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --platforms web,android --no-docs
     
 - name: Build APK
   run: |
@@ -333,7 +333,7 @@ RUN PYTHONPATH=src python -m komodo_codex_env.cli setup --platforms android --no
 export ANDROID_HOME="/opt/android-sdk"
 export PLATFORMS="web,android,linux"
 
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup \
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup \
   --platforms $PLATFORMS \
   --flutter-version 3.32.0 \
   --verbose

--- a/docs/flutter/android/ANDROID_SDK_IMPLEMENTATION.md
+++ b/docs/flutter/android/ANDROID_SDK_IMPLEMENTATION.md
@@ -103,28 +103,28 @@ def get_cmdline_tools_url(self) -> str:
 ### Integrated Setup
 ```bash
 # Install Flutter + Android SDK in parallel
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --platforms web,android
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --platforms web,android
 
 # Skip Android SDK
-PYTHONPATH=src uv run python -m komodo_codex_env.cli setup --no-android
+PYTHONPATH=src rye run python -m komodo_codex_env.cli setup --no-android
 ```
 
 ### Standalone Installation
 ```bash
 # Using the CLI
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-install
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-install
 ```
 
 ### Status and Management
 ```bash
 # Check installation status
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-status
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-status
 
 # Install only Android SDK
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-install
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-install
 
 # Accept licenses
-PYTHONPATH=src uv run python -m komodo_codex_env.cli android-licenses
+PYTHONPATH=src rye run python -m komodo_codex_env.cli android-licenses
 ```
 
 ## Technical Design Decisions


### PR DESCRIPTION
## Summary
- update README to document Rye usage
- include install.sh argument example
- revise docs to remove references to missing files
- switch docs command examples from `uv` to `rye`

## Testing
- `rye run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ca03fc3e883319880b52c273d3c69