### PR TITLE
Default Flutter to stable channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ curl -fsSL https://raw.githubusercontent.com/KomodoPlatform/komodo-codex-env/mai
 
 # Example with custom options
 curl -fsSL https://raw.githubusercontent.com/KomodoPlatform/komodo-codex-env/main/install.sh | bash -s -- \
-  --flutter-version 3.32.0 \
+  --flutter-version stable \
   --platforms web,android \
   --install-type ALL
 ```
@@ -129,7 +129,7 @@ The tool supports configuration via environment variables:
 
 ```bash
 # Flutter version (FVM will manage the actual installation)
-export FLUTTER_VERSION=3.32.0
+export FLUTTER_VERSION=stable
 
 # Platform targets
 export PLATFORMS=web,android,linux
@@ -235,7 +235,7 @@ fvm list
 fvm install 3.29.3
 
 # Set global default
-fvm global 3.32.0
+fvm global stable
 
 # Use for current project
 fvm use 3.29.3

--- a/docs/flutter/FVM_CONFIGURATION.md
+++ b/docs/flutter/FVM_CONFIGURATION.md
@@ -116,14 +116,14 @@ kce-fvm-list
 ```bash
 # Direct FVM commands
 fvm list                    # List installed Flutter versions
-fvm install 3.32.0         # Install specific Flutter version
-fvm use 3.32.0              # Set global Flutter version
+fvm install stable         # Install default Flutter version
+fvm use stable              # Set global Flutter version
 fvm releases                # List available Flutter releases
 
 # Through Komodo Codex Environment
 kce-fvm-list               # List installed versions
-kce-fvm-install 3.32.0     # Install version
-kce-fvm-use 3.32.0         # Switch version
+kce-fvm-install stable     # Install version
+kce-fvm-use stable         # Switch version
 kce-fvm-releases           # List available releases
 
 # Flutter/Dart with FVM

--- a/docs/flutter/android/ANDROID_SDK_GUIDE.md
+++ b/docs/flutter/android/ANDROID_SDK_GUIDE.md
@@ -335,7 +335,7 @@ export PLATFORMS="web,android,linux"
 
 PYTHONPATH=src rye run python -m komodo_codex_env.cli setup \
   --platforms $PLATFORMS \
-  --flutter-version 3.32.0 \
+  --flutter-version stable \
   --verbose
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@
 #
 # After installation, the CLI runs with these default values:
 # - kce-full-setup uses: --platforms web (web only by default, use --platforms web,android,linux for full setup)
-# - Flutter version: 3.32.0 (configurable via --flutter-version)
+# - Flutter version: stable (configurable via --flutter-version)
 # - Install method: precompiled (faster than building from source)
 # - KDF docs: enabled (--kdf-docs flag)
 # - Verbose output: enabled (--verbose flag)
@@ -47,7 +47,7 @@ PYTHON_MIN_VERSION="3.11"
 REQUIRED_PYTHON_VERSION="3.13"
 ALLOW_ROOT=false
 DEBUG=false
-FLUTTER_VERSION="3.32.0"
+FLUTTER_VERSION="stable"
 PLATFORMS="web"
 INSTALL_TYPE="ALL"
 

--- a/src/komodo_codex_env/cli.py
+++ b/src/komodo_codex_env/cli.py
@@ -29,7 +29,7 @@ def cli():
 
 
 @cli.command()
-@click.option("--flutter-version", default="3.32.0", help="Flutter version to install")
+@click.option("--flutter-version", default="stable", help="Flutter version to install")
 @click.option("--install-method", type=click.Choice(["git", "precompiled"]), default="precompiled", help="Flutter installation method")
 @click.option(
     "--install-type",

--- a/src/komodo_codex_env/config.py
+++ b/src/komodo_codex_env/config.py
@@ -22,7 +22,7 @@ class EnvironmentConfig:
     max_parallel_jobs: Optional[int] = None
 
     # Flutter configuration
-    flutter_version: str = "3.32.0"
+    flutter_version: str = "stable"
     flutter_install_method: str = "precompiled"  # "git" or "precompiled"
     platforms: List[str] = field(default_factory=lambda: ["android", "web"])
 

--- a/tests/integration/test_flutter_android_integration.py
+++ b/tests/integration/test_flutter_android_integration.py
@@ -198,7 +198,7 @@ class FlutterAndroidIntegrationTest(unittest.TestCase):
             export USER="testuser" &&
             cd ~/.komodo-codex-env &&
             uv run komodo-codex-env setup \
-                --flutter-version 3.32.0 \
+                --flutter-version stable \
                 --install-method precompiled \
                 --platforms web,android,linux \
                 --verbose

--- a/tests/integration/test_flutter_only_integration.py
+++ b/tests/integration/test_flutter_only_integration.py
@@ -191,7 +191,7 @@ class FlutterOnlyIntegrationTest(unittest.TestCase):
             export USER="testuser" &&
             cd ~/.komodo-codex-env &&
             uv run komodo-codex-env setup \
-                --flutter-version 3.32.0 \
+                --flutter-version stable \
                 --install-method precompiled \
                 --platforms web,linux \
                 --verbose \

--- a/tests/unit/test_android_fvm_paths.py
+++ b/tests/unit/test_android_fvm_paths.py
@@ -199,7 +199,7 @@ class FVMLocationUnitTest(unittest.TestCase):
 
     def test_flutter_version_configuration(self):
         """Test Flutter version configuration through FVM."""
-        flutter_version = "3.32.0"
+        flutter_version = "stable"
         self.config.flutter_version = flutter_version
         
         flutter_manager = FlutterManager(self.config, self.executor, self.dep_manager)
@@ -247,9 +247,9 @@ class EnvironmentConfigurationUnitTest(unittest.TestCase):
     def test_flutter_version_configuration(self):
         """Test Flutter version configuration."""
         config = EnvironmentConfig()
-        config.flutter_version = "3.32.0"
+        config.flutter_version = "stable"
         
-        self.assertEqual(config.flutter_version, "3.32.0")
+        self.assertEqual(config.flutter_version, "stable")
 
     def test_paths_configuration(self):
         """Test path configurations are valid Path objects."""

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -24,7 +24,7 @@ class SetupIntegrationTests(unittest.IsolatedAsyncioTestCase):
             config.platforms = ["web", "android"]
             config.install_android_sdk = True
             config.parallel_execution = True
-            config.flutter_version = "3.32.0"
+            config.flutter_version = "stable"
             config.initial_dir = Path(temp_dir)
             config.android_home = Path(temp_dir) / "Android" / "Sdk"
 
@@ -50,7 +50,7 @@ class SetupIntegrationTests(unittest.IsolatedAsyncioTestCase):
             config.platforms = ["web", "android"]
             config.install_android_sdk = True
             config.parallel_execution = False
-            config.flutter_version = "3.32.0"
+            config.flutter_version = "stable"
             config.initial_dir = Path(temp_dir)
             config.android_home = Path(temp_dir) / "Android" / "Sdk"
 
@@ -71,7 +71,7 @@ class SetupIntegrationTests(unittest.IsolatedAsyncioTestCase):
             config.platforms = ["web", "linux"]
             config.install_android_sdk = True
             config.parallel_execution = True
-            config.flutter_version = "3.32.0"
+            config.flutter_version = "stable"
             config.initial_dir = Path(temp_dir)
 
             setup = EnvironmentSetup(config)
@@ -91,7 +91,7 @@ class SetupIntegrationTests(unittest.IsolatedAsyncioTestCase):
             config.platforms = ["web", "android"]
             config.install_android_sdk = False
             config.parallel_execution = True
-            config.flutter_version = "3.32.0"
+            config.flutter_version = "stable"
             config.initial_dir = Path(temp_dir)
 
             setup = EnvironmentSetup(config)
@@ -111,7 +111,7 @@ class SetupIntegrationTests(unittest.IsolatedAsyncioTestCase):
             config.platforms = ["web", "android"]
             config.install_android_sdk = True
             config.parallel_execution = True
-            config.flutter_version = "3.32.0"
+            config.flutter_version = "stable"
             config.initial_dir = Path(temp_dir)
 
             setup = EnvironmentSetup(config)
@@ -130,7 +130,7 @@ class SetupIntegrationTests(unittest.IsolatedAsyncioTestCase):
             config.platforms = ["web", "android"]
             config.install_android_sdk = True
             config.parallel_execution = True
-            config.flutter_version = "3.32.0"
+            config.flutter_version = "stable"
             config.initial_dir = Path(temp_dir)
 
             setup = EnvironmentSetup(config)


### PR DESCRIPTION
## Summary
- default flutter version to `stable`
- update docs and README for the stable channel
- update integration/unit tests for new default

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6846bd623ea88331bf4287e2e3e47280